### PR TITLE
app: update demo to support discovery kit

### DIFF
--- a/mpfs-rpmsg-bm/src/application/hart0/e51.c
+++ b/mpfs-rpmsg-bm/src/application/hart0/e51.c
@@ -16,7 +16,7 @@
 volatile uint32_t count_sw_ints_h0 = 0U;
 
 const uint8_t g_info_string[] =
-"\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP FreeRTOS example  ****\r\n\r\n\r\n\
+"\r\n\r\n\r\n **** PolarFire SoC AMP FreeRTOS example  ****\r\n\r\n\r\n\
 This program should be run from an application core (U54) in an AMP build.\r\n\r\n\
 For more information refer to the project's README\r\n\
 \r\n";

--- a/mpfs-rpmsg-bm/src/application/inc/demo_main.c
+++ b/mpfs-rpmsg-bm/src/application/inc/demo_main.c
@@ -57,10 +57,10 @@ void start_demo()
 
 #ifdef RPMSG_MASTER
     const uint8_t g_message[] =
-    "\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP RPMsg Master Bare Metal Example ****\r\n\r\n\r\n";
+    "\r\n\r\n\r\n **** PolarFire SoC AMP RPMsg Master Bare Metal Example ****\r\n\r\n\r\n";
 #else
     const uint8_t g_message[] =
-    "\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP RPMsg Remote Bare Metal Example ****\r\n\r\n\r\n";
+    "\r\n\r\n\r\n **** PolarFire SoC AMP RPMsg Remote Bare Metal Example ****\r\n\r\n\r\n";
 #endif
 
     const uint8_t g_menu[] =
@@ -85,9 +85,21 @@ void start_demo()
 #endif
 
 #ifdef RPMSG_MASTER
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart4_lo
+    (void)mss_config_clk_rst(MSS_PERIPH_MMUART4, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+# else
     (void)mss_config_clk_rst(MSS_PERIPH_MMUART1, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart1_lo
+# endif
 #else
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+    (void)mss_config_clk_rst(MSS_PERIPH_MMUART0, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart0_lo
+# else
     (void)mss_config_clk_rst(MSS_PERIPH_MMUART3, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart3_lo
+# endif
 #endif
 
     PLIC_init();

--- a/mpfs-rpmsg-bm/src/application/inc/demo_main.h
+++ b/mpfs-rpmsg-bm/src/application/inc/demo_main.h
@@ -17,9 +17,17 @@
 #define printf_to(...) ee_printf_to(__VA_ARGS__)
 
 #ifdef RPMSG_MASTER
-#define UART_APP &g_mss_uart1_lo
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart4_lo
+# else
+#  define UART_APP &g_mss_uart1_lo
+# endif
 #else
-#define UART_APP &g_mss_uart3_lo
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart0_lo
+# else
+#  define UART_APP &g_mss_uart3_lo
+# endif
 #endif
 
 typedef void *rpmsg_comm_stack_handle_t;

--- a/mpfs-rpmsg-freertos/src/application/hart0/e51.c
+++ b/mpfs-rpmsg-freertos/src/application/hart0/e51.c
@@ -16,7 +16,7 @@
 volatile uint32_t count_sw_ints_h0 = 0U;
 
 const uint8_t g_info_string[] =
-"\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP FreeRTOS example  ****\r\n\r\n\r\n\
+"\r\n\r\n\r\n **** PolarFire SoC AMP FreeRTOS example  ****\r\n\r\n\r\n\
 This program should be run from an application core (U54) in an AMP build.\r\n\r\n\
 For more information refer to the project's README\r\n\
 \r\n";

--- a/mpfs-rpmsg-freertos/src/application/inc/demo_main.c
+++ b/mpfs-rpmsg-freertos/src/application/inc/demo_main.c
@@ -75,9 +75,21 @@ void start_demo()
 #endif
 
 #ifdef RPMSG_MASTER
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart4_lo
+    (void)mss_config_clk_rst(MSS_PERIPH_MMUART4, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+# else
     (void)mss_config_clk_rst(MSS_PERIPH_MMUART1, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart1_lo
+# endif
 #else
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+    (void)mss_config_clk_rst(MSS_PERIPH_MMUART0, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart0_lo
+# else
     (void)mss_config_clk_rst(MSS_PERIPH_MMUART3, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+#  define UART_APP &g_mss_uart3_lo
+# endif
 #endif
 
     PLIC_init();
@@ -124,10 +136,10 @@ void freertos_task_one( void *pvParameters )
 
 #ifdef RPMSG_MASTER
     const uint8_t g_message[] =
-    "\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP RPMsg Master FreeRTOS example ****\r\n\r\n\r\n";
+    "\r\n\r\n\r\n **** PolarFire SoC AMP RPMsg Master FreeRTOS example ****\r\n\r\n\r\n";
 #else
     const uint8_t g_message[] =
-    "\r\n\r\n\r\n **** PolarFire SoC Icicle Kit AMP RPMsg Remote FreeRTOS example ****\r\n\r\n\r\n";
+    "\r\n\r\n\r\n **** PolarFire SoC AMP RPMsg Remote FreeRTOS example ****\r\n\r\n\r\n";
 #endif
 
     const uint8_t g_menu[] =

--- a/mpfs-rpmsg-freertos/src/application/inc/demo_main.h
+++ b/mpfs-rpmsg-freertos/src/application/inc/demo_main.h
@@ -17,9 +17,17 @@
 #define printf_to(...) ee_printf_to(__VA_ARGS__)
 
 #ifdef RPMSG_MASTER
-#define UART_APP &g_mss_uart1_lo
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart4_lo
+# else
+#  define UART_APP &g_mss_uart1_lo
+# endif
 #else
-#define UART_APP &g_mss_uart3_lo
+# if defined(BOARD_MPFS_DISCO_KIT_AMP)
+#  define UART_APP &g_mss_uart0_lo
+# else
+#  define UART_APP &g_mss_uart3_lo
+# endif
 #endif
 
 typedef void *rpmsg_comm_stack_handle_t;


### PR DESCRIPTION
# Description

This pull request aim to add support for MPFS Discovery board. This example have also been integrated in Yocto, please refer to https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp/pull/55

## Type of change

- Update app to UART mapping 
- Update messages to remove exclusive reference to Icicle kit

# How Has This Been Tested?

- Test on MPFS Discovery board using linux AMP examples
- Test on MPFS Icicle Board using linux AMP examples

**Test Configuration**:
* Hardware: MPFS Discovery kit, Icicle Kit
* HSS version: Custom version (49059dbed), in order for the build to run the IHC bug must be fixed, make sure you have an HSS with that fix
* Buildroot / Yocto release: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp/pull/55

# Checklist:

- I have reviewed my code
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have tested that my fix is effective or that my feature works
- I have added a maintainers file for any new board support
